### PR TITLE
fix: use java specific headers

### DIFF
--- a/src/main/java/com/google/events/cloud/audit/v1/Auth.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Auth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/AuthenticationInfo.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/AuthenticationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/AuthenticationInfoThirdPartyPrincipal.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/AuthenticationInfoThirdPartyPrincipal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/AuthorizationInfo.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/AuthorizationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Claims.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Claims.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/DestinationAttributes.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/DestinationAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Detail.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Detail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/FirstPartyPrincipal.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/FirstPartyPrincipal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/LogEntryData.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/LogEntryData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Metadata.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Metadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/NumResponseItems.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/NumResponseItems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Operation.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Operation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ProtoPayload.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ProtoPayload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Request.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/RequestAttributes.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/RequestAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/RequestMetadata.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/RequestMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Resource.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ResourceAttributes.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ResourceAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ResourceLocation.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ResourceLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ResourceOriginalState.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ResourceOriginalState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Response.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ServiceAccountDelegationInfo.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ServiceAccountDelegationInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ServiceAccountDelegationInfoThirdPartyPrincipal.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ServiceAccountDelegationInfoThirdPartyPrincipal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ServiceData.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ServiceData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ServiceMetadata.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ServiceMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/Status.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/audit/v1/ThirdPartyClaims.java
+++ b/src/main/java/com/google/events/cloud/audit/v1/ThirdPartyClaims.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/ArtifactTiming.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/ArtifactTiming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Artifacts.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Artifacts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/BuildEventData.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/BuildEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/BuildEventDataTimeout.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/BuildEventDataTimeout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/DiskSizeGBUnion.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/DiskSizeGBUnion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/FileHashElement.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/FileHashElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/FileHashValue.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/FileHashValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Image.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Image.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/LogStreamingOption.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/LogStreamingOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/LogStreamingOptionEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/LogStreamingOptionEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Logging.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Logging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/LoggingEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/LoggingEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/MachineType.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/MachineType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/MachineTypeEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/MachineTypeEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Objects.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Objects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/ObjectsTiming.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/ObjectsTiming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Options.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Options.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/PullTiming.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/PullTiming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/PushTiming.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/PushTiming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/QueueTTL.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/QueueTTL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/RepoSourceClass.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/RepoSourceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/RequestedVerifyOption.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/RequestedVerifyOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/RequestedVerifyOptionEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/RequestedVerifyOptionEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/ResolvedRepoSourceClass.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/ResolvedRepoSourceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/ResolvedStorageSourceClass.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/ResolvedStorageSourceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Results.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Results.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Secret.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Secret.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Source.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/SourceProvenance.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/SourceProvenance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/SourceProvenanceHashElement.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/SourceProvenanceHashElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Status.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Status.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/StatusEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/StatusEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Step.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Step.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/StepTimeout.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/StepTimeout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/StepTiming.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/StepTiming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/StorageSourceClass.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/StorageSourceClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/SubstitutionOption.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/SubstitutionOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/SubstitutionOptionEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/SubstitutionOptionEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/TimeSpan.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/TimeSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Type.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/TypeEnum.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/TypeEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/cloudbuild/v1/Volume.java
+++ b/src/main/java/com/google/events/cloud/cloudbuild/v1/Volume.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/ArrayValue.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/ArrayValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/DocumentEventData.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/DocumentEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/GeoPointValue.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/GeoPointValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/IntegerValueUnion.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/IntegerValueUnion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/MapValue.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/MapValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/MapValueField.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/MapValueField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/OldValue.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/OldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/OldValueField.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/OldValueField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/UpdateMask.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/UpdateMask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/Value.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/firestore/v1/ValueElement.java
+++ b/src/main/java/com/google/events/cloud/firestore/v1/ValueElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/pubsub/v1/Message.java
+++ b/src/main/java/com/google/events/cloud/pubsub/v1/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/pubsub/v1/MessagePublishedData.java
+++ b/src/main/java/com/google/events/cloud/pubsub/v1/MessagePublishedData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/scheduler/v1/SchedulerJobData.java
+++ b/src/main/java/com/google/events/cloud/scheduler/v1/SchedulerJobData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/storage/v1/CustomerEncryption.java
+++ b/src/main/java/com/google/events/cloud/storage/v1/CustomerEncryption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/storage/v1/Generation.java
+++ b/src/main/java/com/google/events/cloud/storage/v1/Generation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/cloud/storage/v1/StorageObjectData.java
+++ b/src/main/java/com/google/events/cloud/storage/v1/StorageObjectData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/AnalyticsLogData.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/AnalyticsLogData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/AnalyticsValue.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/AnalyticsValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/AppInfo.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/AppInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/BundleInfo.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/BundleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/DeviceInfo.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/DeviceInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/EventDim.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/EventDim.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/GeoInfo.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/GeoInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/IntValue.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/IntValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/LtvInfo.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/LtvInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/TrafficSource.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/TrafficSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/UserDim.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/UserDim.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/UserProperty.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/UserProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/analytics/v1/Value.java
+++ b/src/main/java/com/google/events/firebase/analytics/v1/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/auth/v1/AuthEventData.java
+++ b/src/main/java/com/google/events/firebase/auth/v1/AuthEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/auth/v1/CustomClaims.java
+++ b/src/main/java/com/google/events/firebase/auth/v1/CustomClaims.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/auth/v1/Metadata.java
+++ b/src/main/java/com/google/events/firebase/auth/v1/Metadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/auth/v1/ProviderDatum.java
+++ b/src/main/java/com/google/events/firebase/auth/v1/ProviderDatum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/database/v1/ReferenceEventData.java
+++ b/src/main/java/com/google/events/firebase/database/v1/ReferenceEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.java
+++ b/src/main/java/com/google/events/firebase/remoteconfig/v1/RemoteConfigEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/remoteconfig/v1/RollbackSource.java
+++ b/src/main/java/com/google/events/firebase/remoteconfig/v1/RollbackSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/google/events/firebase/remoteconfig/v1/UpdateUser.java
+++ b/src/main/java/com/google/events/firebase/remoteconfig/v1/UpdateUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-java/issues/38

Last release failed because release please strictly expects these types of headers. See issue.