### PR TITLE
fix: skip clirr step to allow release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,15 +17,22 @@ Then, to generate, run the ./gen.sh file in the java repo. This will generate th
 ./tools/gen.sh
 ```
 
-Observe the new files in `google-cloudevent-types/src/`.
+Observe the new files in `src/`.
 
 ## Test
   
-Run tests in the `google-cloudevent-types` :
+Run tests:
 
 ```sh
-cd google-cloudevent-types
 mvn test
+```
+
+## Prepublish Checklist
+
+Install the library to ensure it builds correctly:
+
+```
+mvn install -Dclirr.skip
 ```
 
 ## How to Contribute

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -29,6 +29,7 @@ create_settings_xml_file "settings.xml"
 mvn clean install deploy -B \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DskipTests=true \
+  -Dclirr.skip \
   -DperformRelease=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -29,7 +29,7 @@ create_settings_xml_file "settings.xml"
 mvn clean install deploy -B \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DskipTests=true \
-  -Dclirr.skip \
+  -Dclirr.skip \ # Ignore running clirr for breaking changes. See #43
   -DperformRelease=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \


### PR DESCRIPTION
Skip clirr check as there are known breaking changes to this artifact (when we changed generators).

- Fixes: https://github.com/googleapis/google-cloudevents-java/issues/40
- Related: https://github.com/googleapis/google-cloudevents-java/issues/43