### PR TITLE
fix: update release process, remove comment

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -29,7 +29,7 @@ create_settings_xml_file "settings.xml"
 mvn clean install deploy -B \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DskipTests=true \
-  -Dclirr.skip \ # Ignore running clirr for breaking changes. See #43
+  -Dclirr.skip \
   -DperformRelease=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \


### PR DESCRIPTION
Removes a comment, which seems to not be allowable in the release script.

Comment added from this review: https://github.com/googleapis/google-cloudevents-java/pull/44#discussion_r523247904

Fixes https://github.com/googleapis/google-cloudevents-java/issues/40#issuecomment-727072463