### PR TITLE
testing: test-generator concurrency per branch

### DIFF
--- a/.github/workflows/test_generation.yaml
+++ b/.github/workflows/test_generation.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     concurrency:
-      group: ${{ github.workflow }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     env:
       LIBRARY_CHECKOUT_PATH: library


### PR DESCRIPTION
## Current Behavior

If the test-generator workflow is running and a new instance of the workflow starts, cancel the running workflow. Even if the workflow is being requested by different branches in the repo.

## Updated Behavior

Concurrency group considers the branch as well, so each PR will be able to run a single instance of the test-generator workflow at a time. New commits should cancel existing runs to start fresh from the latest change.