### PR TITLE
chore: Use renovate addLabels to support all label sources

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,7 +35,7 @@
     "type: process",
   ],
 
-  "labels": [
+  "addLabels": [
     "automerge",
   ],
 
@@ -54,16 +54,16 @@
     {
       "matchUpdateTypes": ["patch"],
       "extends": ["schedule:monthly"],
-      "labels": ["semver: patch"],
+      "addLabels": ["semver: patch"],
     },
     {
       "matchUpdateTypes": ["minor"],
       "extends": ["schedule:quarterly"],
-      "labels": ["semver: minor"],
+      "addLabels": ["semver: minor"],
     },
     {
       "matchUpdateTypes": ["major"],
-      "labels": ["semver: major"],
+      "addLabels": ["semver: major"],
     },
 
     // Tooling & Runtime behaviors.


### PR DESCRIPTION
The use of renovate `labels` removes labels from other automations and manual action whenever renovate runs on a PR. Instead, use `addLabels` so renovate applies merging logic.