### PR TITLE
chore(deps): Update Java 11 to 17 to fix library generation and testing

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Setup Protoc

--- a/.github/workflows/test_generation.yaml
+++ b/.github/workflows/test_generation.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Setup Protoc


### PR DESCRIPTION
According to https://github.com/googleapis/google-cloudevents-java/actions/runs/15500931416/job/43648298775, Java tests on main are failing with an error that seems to indicate a runtime error.

<details>
<summary>Error message copied from build log</summary>
```
Error:  Failed to execute goal com.spotify.fmt:fmt-maven-plugin:2.27:format (default-cli) on project google-cloudevent-types:
Execution default-cli of goal com.spotify.fmt:fmt-maven-plugin:2.27:format failed:
Unable to load the mojo 'format' in the plugin 'com.spotify.fmt:fmt-maven-plugin:2.27' due to an API incompatibility: 
org.codehaus.plexus.component.repository.exception.ComponentLookupException:
com/spotify/fmt/FMT has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```
</details>

Currently, the github workflows that drive library generation and testing are using Java 11. This PR updates it to use Java 17, the next version up that's commonly tested by Google Cloud Java libraries.