### PR TITLE
chore: update java-shared-config to 1.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
+    <version>1.16.1</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
The latest java-shared-config has the profile to disable nexus-staging-maven-plugin. This is part of the mirgation to Central Portal.

Verified with mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer  -Dclirr.skip=true

```
[INFO] --- maven-deploy-plugin:3.1.4:deploy (default-deploy) @ google-cloudevent-types-parent ---
[INFO] Using alternate deployment repository local::default::file:/tmp/maven-staging-dir.gKgMXi
[WARNING] Using legacy syntax for alternative repository. Use "local::file:/tmp/maven-staging-dir.gKgMXi" instead.
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/0.16.0/google-cloudevent-types-parent-0.16.0.pom
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/0.16.0/google-cloudevent-types-parent-0.16.0.pom (3.5 kB at 319 kB/s)
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/0.16.0/google-cloudevent-types-parent-0.16.0-tests.jar
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/0.16.0/google-cloudevent-types-parent-0.16.0-tests.jar (2.7 kB at 886 kB/s)
Downloading from local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/maven-metadata.xml
Downloaded from local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/maven-metadata.xml (328 B at 33 kB/s)
Uploading to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/maven-metadata.xml
Uploaded to local: file:/tmp/maven-staging-dir.gKgMXi/com/google/cloud/google-cloudevent-types-parent/maven-metadata.xml (328 B at 328 kB/s)

```