### PR TITLE
chore: Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directories:
+      - "/"
+      - "/protoc-gen-java-snowpea"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "quarterly"
+
+  	

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,3 @@ updates:
       - "/"
     schedule:
       interval: "quarterly"
-
-  	

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2


### PR DESCRIPTION
Renovate is silently failing to update, enable dependabot for dependency management to find an alternate solution or create another avenue for visibility in dependency update failure.